### PR TITLE
Readme for the w3c/epub repository.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,15 @@
+# Entry point for the W3C EPUB Recommendation
 
-# Specification 'epub'
+This is the entry point on GitHub for the various repositories and documents on the W3C EPUB Recommendation. The Recommendation itself is maintained and developed further by the [W3C Publication Maintenance (PM) Working Group](https://www.w3.org/groups/wg/pm/). 
 
-This is the repository for epub. You're welcome to contribute! Let's make the Web rock our socks
-off!
+EPUB consists of three Recommendations: the authoring format, reading system, and accessibility specifications. The three recommendations are accompanied by a number of Working Group Notes on such diverse topics as multiple rendition, text-to-speech, or accessibility techniques. All of these documents are developed on the [GitHub `epub-spec` repository](https://github.com/w3c/epub-specs/); that is where issues, comments, or pull requests can be raised. Additionally, the Working Group maintains a separate [EPUB Testing repository](https://github.com/w3c/epub-tests/) which contains a large set of publicly available [EPUB tests](https://w3c.github.io/epub-tests/).
+
+The latest stable release of EPUB is version 3.3. The [EPUB 3 Overview for EPUB 3.3](https://www.w3.org/TR/epub-overview-33/) provides a good entry point, including links to all the documents. The document also provides a short overview of the history of EPUB.
+
+The PM Working Group is currently working on version 3.4; see [EPUB 3 Overview for EPUB 3.4](https://www.w3.org/TR/epub-overview-34/) for a detailed reference for that version. The [latest charter](https://www.w3.org/2025/02/pmwg-charter.html) of the Working Group gives some details on the possible additions to the standard.
+
+This repository does not accept issues or pull requests. Please, use the [specification](https://github.com/w3c/epub-specs/) and the [EPUB testing](https://github.com/w3c/epub-tests/) repositories or, possibly, the GitHub [repository of the Working Group](https://github.com/w3c/pm-wg) itself. 
+
+---
+
+@iherman, Staff Contact of the Publishing Maintenance Working Group

--- a/README.md
+++ b/README.md
@@ -2,14 +2,19 @@
 
 This is the entry point on GitHub for the various repositories and documents on the W3C EPUB Recommendation. The Recommendation itself is maintained and developed further by the [W3C Publication Maintenance (PM) Working Group](https://www.w3.org/groups/wg/pm/). 
 
-EPUB consists of three Recommendations: the authoring format, reading system, and accessibility specifications. The three recommendations are accompanied by a number of Working Group Notes on such diverse topics as multiple rendition, text-to-speech, or accessibility techniques. All of these documents are developed on the [GitHub `epub-spec` repository](https://github.com/w3c/epub-specs/); that is where issues, comments, or pull requests can be raised. Additionally, the Working Group maintains a separate [EPUB Testing repository](https://github.com/w3c/epub-tests/) which contains a large set of publicly available [EPUB tests](https://w3c.github.io/epub-tests/).
+This repository does not accept issues or pull requests; it is not where the technical work is happening. Try one of these repositories instead:
 
-The latest stable release of EPUB is version 3.3. The [EPUB 3 Overview for EPUB 3.3](https://www.w3.org/TR/epub-overview-33/) provides a good entry point, including links to all the documents. The document also provides a short overview of the history of EPUB.
+- [EPUB specifications](https://github.com/w3c/epub-specs)
+- [EPUB tests](https://github.com/w3c/epub-tests/)
+- [development of the EPUB conformance (EPUBcheck)](https://github.com/w3c/epubcheck)
+- [W3C publishing community group](https://github.com/w3c/publishingcg)
+- [W3C publishing accessibility task force](https://github.com/w3c/publ-a11y)
+- [localizations of the accessibility metadata display guide for digital publications](https://github.com/w3c/publ-a11y-display-guide-localizations)
+- [digital publishing WAI-ARIA module](https://github.com/w3c/dpub-aria)
+- [digital publishing accessibility API mappings](https://github.com/w3c/dpub-aam)
+- [schema.org accessibility properties for content discoverability](https://github.com/w3c/a11y-discov-vocab)
 
-The PM Working Group is currently working on version 3.4; see [EPUB 3 Overview for EPUB 3.4](https://www.w3.org/TR/epub-overview-34/) for a detailed reference for that version. The [latest charter](https://www.w3.org/2025/02/pmwg-charter.html) of the Working Group gives some details on the possible additions to the standard.
-
-This repository does not accept issues or pull requests. Please, use the [specification](https://github.com/w3c/epub-specs/) and the [EPUB testing](https://github.com/w3c/epub-tests/) repositories or, possibly, the GitHub [repository of the Working Group](https://github.com/w3c/pm-wg) itself. 
 
 ---
 
-@iherman, Staff Contact of the Publishing Maintenance Working Group
+@iherman, staff contact of the Publishing Maintenance Working Group


### PR DESCRIPTION
This is to act upon https://github.com/w3c/epub-specs/issues/2619. It is, essentially, giving a logical entry point to the outside world in finding the EPUB related GitHub entries.

In contrast to what the text says, the repository is still open to issues, in order to handle this PR. Once we get to a consensus as for the content, and this PR gets merged, issues will be disallowed.